### PR TITLE
Modify example to use latest snapshot and fix errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,39 @@
 
     <name>wfs-mdb</name>
 
+    <repositories>
+        <repository>
+            <id>projectodd-snapshots</id>
+            <name>Project:odd Snapshots from CI</name>
+            <url>https://repository-projectodd.forge.cloudbees.com/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>projectodd-snapshots</id>
+            <name>Project:odd Snapshots from CI</name>
+            <url>https://repository-projectodd.forge.cloudbees.com/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.swarm</groupId>
                 <artifactId>wildfly-swarm-plugin</artifactId>
-                <version>1.0.0.Final</version>
+                <version>2016.7-SNAPSHOT</version>
                 <configuration>
                     <mainClass>sample.Main</mainClass>
                 </configuration>
@@ -37,27 +64,27 @@
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>jaxrs-cdi</artifactId>
-            <version>1.0.2.Final</version>
+            <version>2016.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>messaging</artifactId>
-            <version>1.0.2.Final</version>
+            <version>2016.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>remoting</artifactId>
-            <version>1.0.2.Final</version>
+            <version>2016.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>ejb</artifactId>
-            <version>1.0.2.Final</version>
+            <version>2016.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>management</artifactId>
-            <version>1.0.2.Final</version>
+            <version>2016.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>

--- a/src/main/java/sample/client/HelloWorldJMSClient.java
+++ b/src/main/java/sample/client/HelloWorldJMSClient.java
@@ -25,7 +25,7 @@ public class HelloWorldJMSClient {
  
     // Set up all the default value
     private static final String DEFAULT_CONNECTION_FACTORY = "jms/RemoteConnectionFactory";
-    private static final String DEFAULT_DESTINATION = "java:/jms/topic/sample-topic";
+    private static final String DEFAULT_DESTINATION = "jms/topic/sample-topic";
     
     private static final String INITIAL_CONTEXT_FACTORY = "org.jboss.naming.remote.client.InitialContextFactory";
     private static final String PROVIDER_URL = "http-remoting://localhost:8080";
@@ -64,7 +64,7 @@ public class HelloWorldJMSClient {
             log.log(Level.INFO, "Found destination \"{0}\" in JNDI", destinationString);
  
             // Create the JMS connection, session, producer
-            connection = connectionFactory.createConnection();
+            connection = connectionFactory.createConnection("admin", "password");
             session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
             producer = session.createProducer(destination);
            


### PR DESCRIPTION
List of fixes:
- MessagingFraction needed security settings, enable remote access, and define remote topic.
- NamingFraction needed to enable the remote naming service
- RemotingFraction doesn't need to be overriden, so removed
- ManagamentFraction needs to define authz handler
- modifed pom.xml to latest SNAPSHOT version and added CloudBees CI repo
- Client needed to set user/pwd on createConnection()
- Client needed to refer to topic without 'java:' prefix
